### PR TITLE
Convert 'window' and 'msgTimeout' from String to Number when they are provided as msecs. Without this conversion the node does not detect intervals reliably.

### DIFF
--- a/interval_length.js
+++ b/interval_length.js
@@ -152,7 +152,10 @@
                 case "hours":
                     this.window *= 1000 * 60 * 60;
                     break;            
-                default: // "msecs" so no conversion needed
+                default: 
+                    // "msecs" so no conversion needed
+                    // convert from String to Number
+                    this.window *= 1;
             }
         }
         
@@ -168,7 +171,10 @@
                 case "hours":
                     this.msgTimeout *= 1000 * 60 * 60;
                     break;            
-                default: // "msecs" so no conversion needed
+                default: 
+                    // "msecs" so no conversion needed
+                    // convert from String to Number
+                    this.msgTimeout *= 1;
             }
         }
         


### PR DESCRIPTION
This Interval-Length node never sent a message although it received messages that were exactly in this interval scheme and should have triggered it accordingly.
![grafik](https://user-images.githubusercontent.com/4155400/162463086-2cae203a-4ead-4859-b59e-2b5ec30f0298.png)
I assumed it was due to the lack of conversion of 'window' into a Number. As all parameters come in as Strings from the GUI this conversion is necessary for subsequent numerical comparisons. Otherwise the comparisons are alphanumerical, which leads to wrong results.
I tested locally and with the change and my flow works perfectly now.